### PR TITLE
Specify versions of dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
     ],
     "main": "./ascli.js",
     "dependencies": {
-        "colour": "latest",
-        "optjs": "latest"
+        "colour": "~0.7.1",
+        "optjs": "~3.2.2"
     },
     "scripts": {
         "test": "node tests/test.js"


### PR DESCRIPTION
I'm repeatedly getting issues with npm-shrinkwrap with the `"latest"` version specifiers used for `colour` and `optjs`. This is fine for `devDependencies`, but for some reason doesn't work properly for real dependencies. Changing this to more specific version numbers should help for this.
